### PR TITLE
Add ability to set CPU and Memory for scheduled task

### DIFF
--- a/app/controllers/heritages_controller.rb
+++ b/app/controllers/heritages_controller.rb
@@ -76,6 +76,8 @@ class HeritagesController < ApplicationController
       :image_name,
       :image_tag,
       :before_deploy,
+      :scheduled_task_cpu,
+      :scheduled_task_memory,
       services: [
         :name,
         :cpu,

--- a/app/models/heritage_task_definition.rb
+++ b/app/models/heritage_task_definition.rb
@@ -33,8 +33,8 @@ class HeritageTaskDefinition
   def self.schedule_definition(heritage)
     new(heritage: heritage,
         family_name: "#{heritage.name}-schedule",
-        cpu: 128,
-        memory: 512)
+        cpu: heritage.scheduled_task_cpu,
+        memory: heritage.scheduled_task_memory)
   end
 
   def to_task_definition(without_task_role: false, camelize: false)

--- a/db/migrate/20201006024425_add_scheduled_task_settings_to_heritage.rb
+++ b/db/migrate/20201006024425_add_scheduled_task_settings_to_heritage.rb
@@ -1,0 +1,6 @@
+class AddScheduledTaskSettingsToHeritage < ActiveRecord::Migration[5.2]
+  def change
+    add_column :heritages, :scheduled_task_cpu, :integer, null: false, default: 128
+    add_column :heritages, :scheduled_task_memory, :integer, null: false, default: 512
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_06_082137) do
+ActiveRecord::Schema.define(version: 2020_10_06_024425) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -92,6 +92,8 @@ ActiveRecord::Schema.define(version: 2020_05_06_082137) do
     t.string "token"
     t.integer "version"
     t.text "scheduled_tasks"
+    t.integer "scheduled_task_cpu", default: 128, null: false
+    t.integer "scheduled_task_memory", default: 512, null: false
     t.index ["district_id"], name: "index_heritages_on_district_id"
     t.index ["name"], name: "index_heritages_on_name", unique: true
   end

--- a/spec/models/heritage_task_definition_spec.rb
+++ b/spec/models/heritage_task_definition_spec.rb
@@ -357,5 +357,41 @@ describe HeritageTaskDefinition do
                               ]
                            })
     end
+
+    it "returns a task definition for the schedule with the proper params" do
+      allow(heritage).to receive(:scheduled_task_cpu) { 444 }
+      allow(heritage).to receive(:scheduled_task_memory) { 666 }
+      expect(subject).to eq({
+                              "Family" => "#{heritage.name}-schedule",
+                              "TaskRoleArn" => "task-role",
+                              "ExecutionRoleArn" => "task-execution-role",
+                              "ContainerDefinitions" => [
+                                {
+                                  "Name" =>  "#{heritage.name}-schedule",
+                                  "Cpu" => 444,
+                                  "Memory" => 666,
+                                  "Essential" => true,
+                                  "Image" => heritage.image_path,
+                                  "Environment" => [],
+                                  "VolumesFrom" => [
+                                    {
+                                      "SourceContainer" => "runpack",
+                                      "ReadOnly" => true
+                                    }
+                                  ],
+                                  "LogConfiguration" => expected_log_configuration
+                                },
+                                {
+                                  "Name" => "runpack",
+                                  "Cpu" => 1,
+                                  "Memory" => 16,
+                                  "Essential" => false,
+                                  "Image" => "quay.io/degica/barcelona-run-pack",
+                                  "Environment" => [],
+                                  "LogConfiguration" => expected_log_configuration
+                                }
+                              ]
+                           })
+    end
   end
 end

--- a/spec/requests/create_heritage_spec.rb
+++ b/spec/requests/create_heritage_spec.rb
@@ -45,11 +45,10 @@ describe "POST /districts/:district/heritages", type: :request do
     }
   end
 
-
   shared_examples "create" do
     it "creates a heritage" do
       expect(DeployRunnerJob).to receive(:perform_later)
-      api_request(:post, "/v1/districts/#{district.name}/heritages", params)
+      api_request(:post, "/v1/districts/#{district.name}/heritages?debug=true", params)
       expect(response.status).to eq 200
       heritage = JSON.load(response.body)["heritage"]
       expect(heritage["version"]).to eq version
@@ -103,5 +102,18 @@ describe "POST /districts/:district/heritages", type: :request do
   context "when version is 2" do
     let(:version) { 2 }
     it_behaves_like "create"
+
+    it 'accepts scheduled task cpu and memory' do
+      test_params = params
+      test_params[:scheduled_task_cpu] = '100'
+      test_params[:scheduled_task_memory] = '123'
+      api_request(:post, "/v1/districts/#{district.name}/heritages?debug=true", test_params)
+
+      expect(response.status).to eq 200
+
+      heritage = Heritage.last
+      expect(heritage.scheduled_task_memory).to eq 123
+      expect(heritage.scheduled_task_cpu).to eq 100
+    end
   end
 end


### PR DESCRIPTION
Previously it was not possible to set a scheduled task's Memory or CPU usage, and it was pinned at 512MB of RAM and 128 units of CPU. This needs to change as some tasks require more memory.